### PR TITLE
turn seen.keys() dictionary to a list

### DIFF
--- a/osc-install.py
+++ b/osc-install.py
@@ -633,6 +633,7 @@ def _best_platform(self, etc_suse_release, repos, opts):
     max_score = 0
     if len(repos):
         for i in (range(0, len(repos))):
+            repos = list(repos)
             score = self._matches_in_name(repos[i], platform_words)
             if opts.verbose:
                 print("repo %s: score %s" % (repos[i], score))


### PR DESCRIPTION
In python3 var.keys() is a view not a list. To use indexes list() is needed.

fixes https://github.com/openSUSE/osc-plugin-install/issues/3